### PR TITLE
Add people management and history pages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav">
           <li class="nav-item"><a class="nav-link" href="{{ url_for('add_tool') }}">Add Tool</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('people') }}">People</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('report') }}">Report</a></li>
         </ul>
       </div>

--- a/templates/people.html
+++ b/templates/people.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">People</h1>
+<form method="post" class="row g-3 mb-4">
+  <div class="col-auto">
+    <input type="text" class="form-control" name="name" placeholder="New person name" required>
+  </div>
+  <div class="col-auto">
+    <button type="submit" class="btn btn-primary mb-3">Add Person</button>
+  </div>
+</form>
+<table class="table table-striped">
+  <thead>
+    <tr><th>Name</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+  {% for p in people %}
+    <tr>
+      <td><a href="{{ url_for('person_detail', person_id=p.id) }}">{{ p.name }}</a></td>
+      <td>
+        <form action="{{ url_for('delete_person', person_id=p.id) }}" method="post" class="d-inline">
+          <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/person_loans.html
+++ b/templates/person_loans.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">{{ person.name }}'s Borrowing History</h1>
+<table class="table table-striped">
+  <thead>
+    <tr><th>Tool</th><th>Lent On</th><th>Returned On</th></tr>
+  </thead>
+  <tbody>
+  {% for loan in loans %}
+    <tr>
+      <td>{{ loan.tool_name }}</td>
+      <td>{{ loan.lent_on }}</td>
+      <td>{{ loan.returned_on or 'Not returned' }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Introduce `/people` page to list, add, and delete people
- Allow viewing a person's borrowing history
- Link People page in navigation bar

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68acb245de54832482aa97ccf4d3f9a7