### PR TITLE
Allow editing existing tools

### DIFF
--- a/app.py
+++ b/app.py
@@ -162,7 +162,7 @@ def return_tool(tool_id):
                 "UPDATE loans SET returned_on=? WHERE id=?",
                 (returned_on, row[0]),
             )
-            conn.commit()
+        conn.commit()
     return redirect(url_for('index'))
 
 
@@ -181,6 +181,38 @@ def report():
         )
         rows = c.fetchall()
     return render_template('report.html', rows=rows)
+
+
+@app.route('/edit/<int:tool_id>', methods=['GET', 'POST'])
+def edit_tool(tool_id):
+    with get_conn() as conn:
+        c = conn.cursor()
+        if request.method == 'POST':
+            name = request.form['name']
+            description = request.form.get('description', '')
+            value_raw = request.form.get('value')
+            value = float(value_raw) if value_raw else 0
+            image_file = request.files.get('image')
+            if image_file and image_file.filename:
+                os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+                filename = secure_filename(image_file.filename)
+                save_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+                image_file.save(save_path)
+                image_path = os.path.join('images', filename)
+                c.execute(
+                    "UPDATE tools SET name=?, description=?, value=?, image_path=? WHERE id=?",
+                    (name, description, value, image_path, tool_id),
+                )
+            else:
+                c.execute(
+                    "UPDATE tools SET name=?, description=?, value=? WHERE id=?",
+                    (name, description, value, tool_id),
+                )
+            conn.commit()
+            return redirect(url_for('index'))
+        c.execute("SELECT * FROM tools WHERE id=?", (tool_id,))
+        tool = c.fetchone()
+    return render_template('edit_tool.html', tool=tool)
 
 
 if __name__ == '__main__':

--- a/templates/edit_tool.html
+++ b/templates/edit_tool.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Edit Tool</h1>
+<form method="post" enctype="multipart/form-data" class="row g-3">
+  <div class="col-12">
+    <label class="form-label">Name</label>
+    <input type="text" class="form-control" name="name" value="{{ tool.name }}" required>
+  </div>
+  <div class="col-12">
+    <label class="form-label">Description</label>
+    <input type="text" class="form-control" name="description" value="{{ tool.description }}">
+  </div>
+  <div class="col-12">
+    <label class="form-label">Value</label>
+    <input type="number" step="0.01" class="form-control" name="value" value="{{ tool.value }}">
+  </div>
+  <div class="col-12">
+    <label class="form-label">Image</label>
+    {% if tool.image_path %}
+    <div class="mb-2"><img src="{{ url_for('static', filename=tool.image_path) }}" width="128" class="img-thumbnail"></div>
+    {% endif %}
+    <input type="file" class="form-control" name="image">
+  </div>
+  <div class="col-12">
+    <button type="submit" class="btn btn-primary">Update</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
   {% for t in tools %}
   <tr>
     <td>{{ t.id }}</td>
-    <td>{{ t.name }}</td>
+    <td><a href="{{ url_for('edit_tool', tool_id=t.id) }}">{{ t.name }}</a></td>
     <td>${{ '%.2f'|format(t.value or 0) }}</td>
     <td>{% if t.image_path %}<img src="{{ url_for('static', filename=t.image_path) }}" width="64" class="img-thumbnail">{% endif %}</td>
     <td>{% if t.borrower %}Lent to {{ t.borrower }} on {{ t.lent_on }}{% else %}Available{% endif %}</td>


### PR DESCRIPTION
## Summary
- Add link from tool list to an edit page
- Introduce edit page to modify tool details and image
- Support saving updates via new `/edit/<id>` route

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68acb25e01dc832480a4e67bc629951a