### PR TITLE
Require existing people for lending and add contact info

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,10 +35,16 @@ def init_db():
             """
             CREATE TABLE IF NOT EXISTS people (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL UNIQUE
+                name TEXT NOT NULL UNIQUE,
+                contact_info TEXT
             )
             """
         )
+        # Ensure contact_info column exists for older databases
+        try:
+            c.execute("ALTER TABLE people ADD COLUMN contact_info TEXT")
+        except sqlite3.OperationalError:
+            pass
         c.execute(
             """
             CREATE TABLE IF NOT EXISTS loans (
@@ -120,7 +126,7 @@ def delete_tool(tool_id):
 @app.route('/lend/<int:tool_id>', methods=['GET', 'POST'])
 def lend_tool(tool_id):
     if request.method == 'POST':
-        person = request.form['person']
+        person_id = request.form.get('person_id')
         with get_conn() as conn:
             c = conn.cursor()
             c.execute(
@@ -130,21 +136,26 @@ def lend_tool(tool_id):
             if c.fetchone()[0] > 0:
                 flash('Tool already lent out')
             else:
-                c.execute("SELECT id FROM people WHERE name=?", (person,))
+                c.execute("SELECT id FROM people WHERE id=?", (person_id,))
                 row = c.fetchone()
-                if row:
-                    person_id = row[0]
+                if not row:
+                    flash('Person not found')
                 else:
-                    c.execute("INSERT INTO people (name) VALUES (?)", (person,))
-                    person_id = c.lastrowid
-                lent_on = datetime.date.today().isoformat()
-                c.execute(
-                    "INSERT INTO loans (tool_id, person_id, lent_on) VALUES (?, ?, ?)",
-                    (tool_id, person_id, lent_on),
-                )
-                conn.commit()
+                    lent_on = datetime.date.today().isoformat()
+                    c.execute(
+                        "INSERT INTO loans (tool_id, person_id, lent_on) VALUES (?, ?, ?)",
+                        (tool_id, person_id, lent_on),
+                    )
+                    conn.commit()
         return redirect(url_for('index'))
-    return render_template('lend_tool.html', tool_id=tool_id)
+    with get_conn() as conn:
+        c = conn.cursor()
+        c.execute("SELECT id, name FROM people ORDER BY name")
+        people = c.fetchall()
+        if not people:
+            flash('No people available. Add a person first.')
+            return redirect(url_for('people'))
+    return render_template('lend_tool.html', tool_id=tool_id, people=people)
 
 
 @app.route('/return/<int:tool_id>', methods=['POST'])
@@ -170,17 +181,21 @@ def return_tool(tool_id):
 def people():
     if request.method == 'POST':
         name = request.form['name']
+        contact_info = request.form.get('contact_info', '')
         with get_conn() as conn:
             c = conn.cursor()
             try:
-                c.execute("INSERT INTO people (name) VALUES (?)", (name,))
+                c.execute(
+                    "INSERT INTO people (name, contact_info) VALUES (?, ?)",
+                    (name, contact_info),
+                )
                 conn.commit()
             except sqlite3.IntegrityError:
                 flash('Person already exists')
         return redirect(url_for('people'))
     with get_conn() as conn:
         c = conn.cursor()
-        c.execute("SELECT id, name FROM people ORDER BY name")
+        c.execute("SELECT id, name, contact_info FROM people ORDER BY name")
         people = c.fetchall()
     return render_template('people.html', people=people)
 
@@ -202,7 +217,7 @@ def delete_person(person_id):
 def person_detail(person_id):
     with get_conn() as conn:
         c = conn.cursor()
-        c.execute("SELECT name FROM people WHERE id=?", (person_id,))
+        c.execute("SELECT name, contact_info FROM people WHERE id=?", (person_id,))
         person = c.fetchone()
         if not person:
             return redirect(url_for('people'))
@@ -218,6 +233,29 @@ def person_detail(person_id):
         )
         loans = c.fetchall()
     return render_template('person_loans.html', person=person, loans=loans)
+
+
+@app.route('/people/<int:person_id>/edit', methods=['GET', 'POST'])
+def edit_person(person_id):
+    with get_conn() as conn:
+        c = conn.cursor()
+        if request.method == 'POST':
+            name = request.form['name']
+            contact_info = request.form.get('contact_info', '')
+            try:
+                c.execute(
+                    "UPDATE people SET name=?, contact_info=? WHERE id=?",
+                    (name, contact_info, person_id),
+                )
+                conn.commit()
+                return redirect(url_for('people'))
+            except sqlite3.IntegrityError:
+                flash('Person already exists')
+        c.execute("SELECT id, name, contact_info FROM people WHERE id=?", (person_id,))
+        person = c.fetchone()
+        if not person:
+            return redirect(url_for('people'))
+    return render_template('edit_person.html', person=person)
 
 
 @app.route('/report')

--- a/templates/edit_person.html
+++ b/templates/edit_person.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Edit Person</h1>
+<form method="post" class="row g-3">
+  <div class="col-md-6">
+    <label class="form-label">Name</label>
+    <input type="text" class="form-control" name="name" value="{{ person.name }}" required>
+  </div>
+  <div class="col-md-6">
+    <label class="form-label">Contact Info</label>
+    <input type="text" class="form-control" name="contact_info" value="{{ person.contact_info }}">
+  </div>
+  <div class="col-12">
+    <button type="submit" class="btn btn-primary">Save</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/lend_tool.html
+++ b/templates/lend_tool.html
@@ -4,7 +4,12 @@
 <form method="post" class="row g-3">
   <div class="col-12">
     <label class="form-label">Person</label>
-    <input type="text" class="form-control" name="person" required>
+    <select class="form-select" name="person_id" required>
+      <option value="" disabled selected>Select person</option>
+      {% for p in people %}
+      <option value="{{ p.id }}">{{ p.name }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div class="col-12">
     <button type="submit" class="btn btn-primary">Lend</button>

--- a/templates/people.html
+++ b/templates/people.html
@@ -2,8 +2,11 @@
 {% block content %}
 <h1 class="mb-4">People</h1>
 <form method="post" class="row g-3 mb-4">
-  <div class="col-auto">
-    <input type="text" class="form-control" name="name" placeholder="New person name" required>
+  <div class="col-md-4">
+    <input type="text" class="form-control" name="name" placeholder="Name" required>
+  </div>
+  <div class="col-md-4">
+    <input type="text" class="form-control" name="contact_info" placeholder="Contact info">
   </div>
   <div class="col-auto">
     <button type="submit" class="btn btn-primary mb-3">Add Person</button>
@@ -11,13 +14,15 @@
 </form>
 <table class="table table-striped">
   <thead>
-    <tr><th>Name</th><th>Actions</th></tr>
+    <tr><th>Name</th><th>Contact Info</th><th>Actions</th></tr>
   </thead>
   <tbody>
   {% for p in people %}
     <tr>
       <td><a href="{{ url_for('person_detail', person_id=p.id) }}">{{ p.name }}</a></td>
+      <td>{{ p.contact_info }}</td>
       <td>
+        <a href="{{ url_for('edit_person', person_id=p.id) }}" class="btn btn-sm btn-secondary">Edit</a>
         <form action="{{ url_for('delete_person', person_id=p.id) }}" method="post" class="d-inline">
           <button type="submit" class="btn btn-sm btn-danger">Delete</button>
         </form>

--- a/templates/person_loans.html
+++ b/templates/person_loans.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">{{ person.name }}'s Borrowing History</h1>
+<p><strong>Contact:</strong> {{ person.contact_info }}</p>
 <table class="table table-striped">
   <thead>
     <tr><th>Tool</th><th>Lent On</th><th>Returned On</th></tr>


### PR DESCRIPTION
## Summary
- add contact_info column for people and support editing their details
- require tools be lent only to existing people selected from dropdown

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile passed'`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68acb3a5b85883248283eebc279bf24a