### PR TITLE
Enable searchable lending person selector and inline addition

### DIFF
--- a/static/js/lend.js
+++ b/static/js/lend.js
@@ -1,0 +1,32 @@
+const select = document.getElementById('person-select');
+const searchInput = document.getElementById('person-search');
+
+// Filter people as user types
+if (searchInput && select) {
+  searchInput.addEventListener('input', () => {
+    const term = searchInput.value.toLowerCase();
+    Array.from(select.options).forEach(opt => {
+      if (!opt.value || opt.value === '__add_new__') return;
+      const text = opt.textContent.toLowerCase();
+      opt.hidden = !text.includes(term);
+    });
+  });
+
+  select.addEventListener('change', () => {
+    if (select.value === '__add_new__') {
+      const name = prompt('Enter name for new person:');
+      if (!name) {
+        select.value = '';
+        return;
+      }
+      const contact = prompt('Enter contact info (optional):') || '';
+      fetch('/people', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ name: name, contact_info: contact })
+      }).then(() => {
+        window.location.reload();
+      });
+    }
+  });
+}

--- a/templates/lend_tool.html
+++ b/templates/lend_tool.html
@@ -4,15 +4,18 @@
 <form method="post" class="row g-3">
   <div class="col-12">
     <label class="form-label">Person</label>
-    <select class="form-select" name="person_id" required>
+    <input type="text" id="person-search" class="form-control mb-2" placeholder="Search people">
+    <select class="form-select" name="person_id" required id="person-select">
       <option value="" disabled selected>Select person</option>
       {% for p in people %}
       <option value="{{ p.id }}">{{ p.name }}</option>
       {% endfor %}
+      <option value="__add_new__">Add new person...</option>
     </select>
   </div>
   <div class="col-12">
     <button type="submit" class="btn btn-primary">Lend</button>
   </div>
 </form>
+<script src="{{ url_for('static', filename='js/lend.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add search field and "Add new person" option to lending page's person selector.
- Include JavaScript to filter people and create new entries on the fly.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68acbc9b1398832491bd05e5e8231ac8