### PR TITLE
Enable searchable lending person selector and inline addition

### DIFF
--- a/static/js/lend.js
+++ b/static/js/lend.js
@@ -1,0 +1,73 @@
+const searchInput = document.getElementById('person-search');
+const results = document.getElementById('person-results');
+const personId = document.getElementById('person-id');
+const showAdd = document.getElementById('show-add-person');
+const addForm = document.getElementById('add-person-form');
+const addName = document.getElementById('new-person-name');
+const addContact = document.getElementById('new-person-contact');
+const addSubmit = document.getElementById('add-person-submit');
+const form = document.querySelector('form');
+const people = (window.peopleData || []).map(p => ({ id: p[0], name: p[1] }));
+
+// Search and select existing people
+if (searchInput) {
+  searchInput.addEventListener('input', () => {
+    const term = searchInput.value.toLowerCase();
+    results.innerHTML = '';
+    personId.value = '';
+    if (!term) {
+      results.classList.add('d-none');
+      return;
+    }
+    const matches = people.filter(p => p.name.toLowerCase().includes(term));
+    matches.forEach(p => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'list-group-item list-group-item-action';
+      btn.textContent = p.name;
+      btn.dataset.id = p.id;
+      results.appendChild(btn);
+    });
+    results.classList.toggle('d-none', matches.length === 0);
+  });
+
+  results.addEventListener('click', (e) => {
+    const id = e.target.dataset.id;
+    if (!id) return;
+    personId.value = id;
+    searchInput.value = e.target.textContent;
+    results.classList.add('d-none');
+  });
+}
+
+// Inline add person form
+if (showAdd) {
+  showAdd.addEventListener('click', () => {
+    addForm.classList.toggle('d-none');
+  });
+
+  addSubmit.addEventListener('click', () => {
+    const name = addName.value.trim();
+    if (!name) {
+      return;
+    }
+    fetch('/people', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ name: name, contact_info: addContact.value })
+    }).then(() => {
+      window.location.reload();
+    });
+  });
+}
+
+// Ensure a person is chosen before submitting
+if (form && personId) {
+  form.addEventListener('submit', (e) => {
+    if (!personId.value) {
+      e.preventDefault();
+      searchInput.focus();
+    }
+  });
+}
+

--- a/templates/lend_tool.html
+++ b/templates/lend_tool.html
@@ -4,15 +4,28 @@
 <form method="post" class="row g-3">
   <div class="col-12">
     <label class="form-label">Person</label>
-    <select class="form-select" name="person_id" required>
-      <option value="" disabled selected>Select person</option>
-      {% for p in people %}
-      <option value="{{ p.id }}">{{ p.name }}</option>
-      {% endfor %}
-    </select>
+    <input type="text" id="person-search" class="form-control mb-2" placeholder="Search people">
+    <div id="person-results" class="list-group mb-2 d-none"></div>
+    <button type="button" id="show-add-person" class="btn btn-link p-0">Add new person</button>
+    <div id="add-person-form" class="row g-2 mt-2 d-none">
+      <div class="col-md-4">
+        <input type="text" id="new-person-name" class="form-control" placeholder="Name">
+      </div>
+      <div class="col-md-4">
+        <input type="text" id="new-person-contact" class="form-control" placeholder="Contact info">
+      </div>
+      <div class="col-auto">
+        <button type="button" id="add-person-submit" class="btn btn-secondary">Save</button>
+      </div>
+    </div>
+    <input type="hidden" name="person_id" id="person-id" required>
   </div>
   <div class="col-12">
     <button type="submit" class="btn btn-primary">Lend</button>
   </div>
 </form>
+<script>
+  window.peopleData = {{ people|tojson }};
+</script>
+<script src="{{ url_for('static', filename='js/lend.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace person dropdown with a searchable input that displays matching people.
- Add inline form to create a new borrower without pop-up prompts.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68acbc9b1398832491bd05e5e8231ac8